### PR TITLE
mini-rv32ima: Makefile: Added -e flag to bintoh.c echo

### DIFF
--- a/mini-rv32ima/Makefile
+++ b/mini-rv32ima/Makefile
@@ -33,7 +33,7 @@ testdlimage : mini-rv32ima DownloadedImage
 
 # For converting the .dtb into a .h file for embeddding.
 bintoh :
-	echo "#include <stdio.h>\nint main(int argc,char ** argv) {if(argc==1) return -1; int c, p=0; printf( \"static const unsigned char %s[] = {\", argv[1] ); while( ( c = getchar() ) != EOF ) printf( \"0x%02x,%c\", c, (((p++)&15)==15)?10:' '); printf( \"};\" ); }" > bintoh.c
+	echo -e "#include <stdio.h>\nint main(int argc,char ** argv) {if(argc==1) return -1; int c, p=0; printf( \"static const unsigned char %s[] = {\", argv[1] ); while( ( c = getchar() ) != EOF ) printf( \"0x%02x,%c\", c, (((p++)&15)==15)?10:' '); printf( \"};\" ); }" > bintoh.c
 	gcc bintoh.c -o bintoh
 
 default64mbdtc.h : sixtyfourmb.dtb bintoh


### PR DESCRIPTION
Added an `-e` flag to the `echo` command so the `\n` character would print as a newline in the file. 

`make everything` produced the following error without it (after adding the flag it passed with no issues):
```
>>>   Executing post-image script board/qemu/post-image.sh
make[1]: Leaving directory '/home/czarnobylu/git/mini-rv32ima/buildroot'
make -C mini-rv32ima testkern
make[1]: Entering directory '/home/czarnobylu/git/mini-rv32ima/mini-rv32ima'
echo "#include <stdio.h>\\nint main(int argc,char ** argv) {if(argc==1) return -1; int c, p=0; printf( \"static const unsigned char %s[] = {\", argv[1] ); while( ( c = getchar() ) != EOF ) printf( \"0x%02x,%c\", c, (((p++)&15)==15)?10:' '); printf( \"};\" ); }" > bintoh.c
gcc bintoh.c -o bintoh
bintoh.c:1:19: warning: extra tokens at end of #include directive
    1 | #include <stdio.h>\nint main(int argc,char ** argv) {if(argc==1) return -1; int c, p=0; printf( "static const unsigned char %s[] = {", argv[1] ); while( ( c = getchar() ) != EOF ) printf( "0x%02x,%c", c, (((p++)&15)==15)?10:' '); printf( "};" ); }
      |                   ^
/usr/bin/ld: /usr/lib/gcc/x86_64-pc-linux-gnu/12.1.1/../../../../lib/Scrt1.o: in function `_start':
/build/glibc/src/glibc/csu/../sysdeps/x86_64/start.S:103: undefined reference to `main'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:37: bintoh] Error 1
make[1]: Leaving directory '/home/czarnobylu/git/mini-rv32ima/mini-rv32ima'
make: *** [Makefile:19: everything] Error 2
```
