### PR TITLE
Maximize debug level for `mini-rv32ima` executable

### DIFF
--- a/mini-rv32ima/Makefile
+++ b/mini-rv32ima/Makefile
@@ -2,7 +2,7 @@ all : mini-rv32ima mini-rv32ima.flt
 
 mini-rv32ima : mini-rv32ima.c mini-rv32ima.h default64mbdtc.h
 	# for debug
-	gcc -o $@ $< -g -O4 -Wall
+	gcc -o $@ $< -g3 -Wall
 	gcc -o $@.tiny $< -Os -ffunction-sections -fdata-sections -Wl,--gc-sections -fwhole-program -s
 
 mini-rv32ima.flt : mini-rv32ima.c mini-rv32ima.h


### PR DESCRIPTION
Using `-O4` makes it harder to debug using `gdb`: the program flow does not follow source code lines, instead it follows the optimized flow.