### PR TITLE
Support ANSI term256 colour

### DIFF
--- a/experiments/emdoom/Makefile
+++ b/experiments/emdoom/Makefile
@@ -1,5 +1,7 @@
 all : build
 
+#CFLAGS_EXTRA:=-DTERM256
+
 test : build
 	cp embeddeddoom/src/emdoom ../../buildroot/output/target/root
 	make -C ../.. toolchain
@@ -10,7 +12,7 @@ launch :
 	../../mini-rv32ima/mini-rv32ima -f ../../buildroot/output/images/Image -m 0x4000000
 
 build : embeddeddoom
-	CC=../../../../buildroot/output/host/usr/bin/riscv32-buildroot-linux-uclibc-gcc CFLAGS="-mabi=ilp32 -fPIE -pie -flto" CFLAGS_FINAL="-mabi=ilp32 -flto -fPIE -pie -static -march=rv32ima -O4 -s -g -DNORMALUNIX -DLINUX -DMAXPLAYERS=1 -DDISABLE_NETWORK -static-libgcc -DSET_MEMORY_DEBUG=0 -DRANGECHECK -fdata-sections -ffunction-sections" LDFLAGS='-Wl,-elf2flt="-r -s 36000" -static -Wl,-Map=../../output.map -Wl,--gc-sections -flto' LIBS="" CS="../../video_console.c ../../extra_assembly.S" make -C embeddeddoom/src
+	CC=../../../../buildroot/output/host/usr/bin/riscv32-buildroot-linux-uclibc-gcc CFLAGS="-mabi=ilp32 -fPIE -pie -flto" CFLAGS_FINAL="-mabi=ilp32 -flto -fPIE -pie -static -march=rv32ima -O4 -s -g -DNORMALUNIX -DLINUX $(CFLAGS_EXTRA) -DMAXPLAYERS=1 -DDISABLE_NETWORK -static-libgcc -DSET_MEMORY_DEBUG=0 -DRANGECHECK -fdata-sections -ffunction-sections" LDFLAGS='-Wl,-elf2flt="-r -s 36000" -static -Wl,-Map=../../output.map -Wl,--gc-sections -flto' LIBS="" CS="../../video_console.c ../../extra_assembly.S ../../tmux_colour.c" make -C embeddeddoom/src
 	../../buildroot/output/host/usr/bin/riscv32-buildroot-linux-uclibc-size -A embeddeddoom/src/emdoom.gdb
 	../../buildroot/output/host/usr/bin/riscv32-buildroot-linux-uclibc-objdump -S embeddeddoom/src/emdoom.gdb > emdoom_listing.txt
 
@@ -20,7 +22,7 @@ build : embeddeddoom
 
 # Only for desktop testing, almost never use.
 desktop : embeddeddoom
-	CFLAGS="-m32" CFLAGS_FINAL="-m32 -DRANGECHECK -DNORMALUNIX -DLINUX -DMAXPLAYERS=1 -DDISABLE_NETWORK -DSET_MEMORY_DEBUG=0 -DIS_ON_DESKTOP_NOT_RV_EMULATOR -fsanitize=address -static-libasan -g -Wl,-Map=../../output.map " LDFLAGS='' LIBS="" CS="../../video_console.c" make -C embeddeddoom/src
+	CFLAGS="-m32" CFLAGS_FINAL="-m32 -DRANGECHECK -DNORMALUNIX -DLINUX $(CFLAGS_EXTRA) -DMAXPLAYERS=1 -DDISABLE_NETWORK -DSET_MEMORY_DEBUG=0 -DIS_ON_DESKTOP_NOT_RV_EMULATOR -fsanitize=address -static-libasan -g -Wl,-Map=../../output.map " LDFLAGS='' LIBS="" CS="../../video_console.c ../../tmux_colour.c" make -C embeddeddoom/src
 
 # If we were going to try to make a bare-metal version.
 # -T ../../flatfile.lds

--- a/experiments/emdoom/tmux_colour.c
+++ b/experiments/emdoom/tmux_colour.c
@@ -1,0 +1,88 @@
+/* $OpenBSD$ */
+
+/*
+ * Copyright (c) 2008 Nicholas Marriott <nicholas.marriott@gmail.com>
+ * Copyright (c) 2016 Avi Halachmi <avihpit@yahoo.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF MIND, USE, DATA OR PROFITS, WHETHER
+ * IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#define COLOUR_FLAG_256 0
+
+static int
+colour_dist_sq(int R, int G, int B, int r, int g, int b)
+{
+	return ((R - r) * (R - r) + (G - g) * (G - g) + (B - b) * (B - b));
+}
+
+static int
+colour_to_6cube(int v)
+{
+	if (v < 48)
+		return (0);
+	if (v < 114)
+		return (1);
+	return ((v - 35) / 40);
+}
+
+/*
+ * Convert an RGB triplet to the xterm(1) 256 colour palette.
+ *
+ * xterm provides a 6x6x6 colour cube (16 - 231) and 24 greys (232 - 255). We
+ * map our RGB colour to the closest in the cube, also work out the closest
+ * grey, and use the nearest of the two.
+ *
+ * Note that the xterm has much lower resolution for darker colours (they are
+ * not evenly spread out), so our 6 levels are not evenly spread: 0x0, 0x5f
+ * (95), 0x87 (135), 0xaf (175), 0xd7 (215) and 0xff (255). Greys are more
+ * evenly spread (8, 18, 28 ... 238).
+ */
+int
+colour_find_rgb(u_char r, u_char g, u_char b)
+{
+	static const int	q2c[6] = { 0x00, 0x5f, 0x87, 0xaf, 0xd7, 0xff };
+	int			qr, qg, qb, cr, cg, cb, d, idx;
+	int			grey_avg, grey_idx, grey;
+
+	/* Map RGB to 6x6x6 cube. */
+	qr = colour_to_6cube(r); cr = q2c[qr];
+	qg = colour_to_6cube(g); cg = q2c[qg];
+	qb = colour_to_6cube(b); cb = q2c[qb];
+
+	/* If we have hit the colour exactly, return early. */
+	if (cr == r && cg == g && cb == b)
+		return ((16 + (36 * qr) + (6 * qg) + qb) | COLOUR_FLAG_256);
+
+	/* Work out the closest grey (average of RGB). */
+	grey_avg = (r + g + b) / 3;
+	if (grey_avg > 238)
+		grey_idx = 23;
+	else
+		grey_idx = (grey_avg - 3) / 10;
+	grey = 8 + (10 * grey_idx);
+
+	/* Is grey or 6x6x6 colour closest? */
+	d = colour_dist_sq(cr, cg, cb, r, g, b);
+	if (colour_dist_sq(grey, grey, grey, r, g, b) < d)
+		idx = 232 + grey_idx;
+	else
+		idx = 16 + (36 * qr) + (6 * qg) + qb;
+	return (idx | COLOUR_FLAG_256);
+}


### PR DESCRIPTION
Added ANSI 256 colour mapping (borrowed 'with due respect' from tmux)
Ascii characters derived from a shademap (10 character spread)
Significantly improves quality at cost of some performance + terminal bandwidth velocity
Enabled in emdoom/Makefile
