### PR TITLE
Switch from -O3 optimization to -O2

### DIFF
--- a/mini-rv32ima/Makefile
+++ b/mini-rv32ima/Makefile
@@ -2,7 +2,7 @@ all : mini-rv32ima mini-rv32ima.flt
 
 mini-rv32ima : mini-rv32ima.c mini-rv32ima.h default64mbdtc.h
 	# for debug
-	gcc -o $@ $< -g -O4 -Wall
+	gcc -o $@ $< -g -O2 -Wall
 	gcc -o $@.tiny $< -Os -ffunction-sections -fdata-sections -Wl,--gc-sections -fwhole-program -s
 
 mini-rv32ima.flt : mini-rv32ima.c mini-rv32ima.h


### PR DESCRIPTION
GCC (11.3) rounds off `-O4` to the maximum supported `-O3`.  On my (fairly modest) laptop that yields a CoreMark score of about 425.  Using `-O2` instead I get about 470, so do that.

You should probably check this on your machine as well, but as far as I know GCC’s `-O3` indeed makes things worse about as often as it makes them better, depending on the kind of the program, and given an interpreter loop is a fairly bad case for the optimizer this result looks reasonable to me.

Your Makefile explicitly mentions GCC so I don’t expect it matters that much, but on the same laptop an emulator compiled with Clang 14 scores about 395 with `-O2` and about 405 with `-O3`.