### PR TITLE
baremetal: initial stack pointer

### DIFF
--- a/baremetal/baremetal.S
+++ b/baremetal/baremetal.S
@@ -5,7 +5,7 @@
 
 .align 4
 _start:
-	lui sp, 0x80100
+	la	sp, _sstack
 	addi	sp,sp,-16
 	sw	ra,12(sp)
 	jal	ra, main


### PR DESCRIPTION
The initial stack pointer is currently set up using `lui sp, 0x80100` in [`baremetal.S`](https://github.com/cnlohr/mini-rv32ima/blob/a6be785a6d768d9e36d5efd3358f67fe56ca236a/baremetal/baremetal.S#L8).

Since the stack is also defined in the [linker file](https://github.com/cnlohr/mini-rv32ima/blob/a6be785a6d768d9e36d5efd3358f67fe56ca236a/baremetal/flatfile.lds#L73), it is instead possible to use `la sp, _sstack` to get the exact stack address computed by the linker.

Note that since `la` is a pseudo instruction, it is converted by the compiler to the following code:

```asm
80000000 <__TEXT_BEGIN__>:
80000000:	00002117          	auipc	sp,0x2
80000004:	1c010113          	addi	sp,sp,448 # 800021c0 <_sstack>
```

