### PR TITLE
fix control memory address calculations

### DIFF
--- a/experiments/profiling_structure/baseline.h
+++ b/experiments/profiling_structure/baseline.h
@@ -202,7 +202,7 @@ MINIRV32_DECORATE int32_t MiniRV32IMAStep( struct MiniRV32IMAState * state, uint
 					rsval -= MINIRV32_RAM_IMAGE_OFFSET;
 					if( rsval >= MINI_RV32_RAM_SIZE-3 )
 					{
-						rsval -= MINIRV32_RAM_IMAGE_OFFSET;
+						rsval += MINIRV32_RAM_IMAGE_OFFSET;
 						if( rsval >= 0x10000000 && rsval < 0x12000000 )  // UART, CLNT
 						{
 							if( rsval == 0x1100bffc ) // https://chromitem-soc.readthedocs.io/en/latest/clint.html
@@ -244,7 +244,7 @@ MINIRV32_DECORATE int32_t MiniRV32IMAStep( struct MiniRV32IMAState * state, uint
 
 					if( addy >= MINI_RV32_RAM_SIZE-3 )
 					{
-						addy -= MINIRV32_RAM_IMAGE_OFFSET;
+						addy += MINIRV32_RAM_IMAGE_OFFSET;
 						if( addy >= 0x10000000 && addy < 0x12000000 ) 
 						{
 							// Should be stuff like SYSCON, 8250, CLNT
@@ -263,7 +263,7 @@ MINIRV32_DECORATE int32_t MiniRV32IMAStep( struct MiniRV32IMAState * state, uint
 						else
 						{
 							trap = (7+1); // Store access fault.
-							rval = addy + MINIRV32_RAM_IMAGE_OFFSET;
+							rval = addy;
 						}
 					}
 					else

--- a/experiments/profiling_structure/functioncall.h
+++ b/experiments/profiling_structure/functioncall.h
@@ -175,7 +175,7 @@ static inline uint32_t CallStep( struct MiniRV32IMAState * state, uint8_t * imag
 			rsval -= MINIRV32_RAM_IMAGE_OFFSET;
 			if( rsval >= MINI_RV32_RAM_SIZE-3 )
 			{
-				rsval -= MINIRV32_RAM_IMAGE_OFFSET;
+				rsval += MINIRV32_RAM_IMAGE_OFFSET;
 				if( rsval >= 0x10000000 && rsval < 0x12000000 )  // UART, CLNT
 				{
 					if( rsval == 0x1100bffc ) // https://chromitem-soc.readthedocs.io/en/latest/clint.html
@@ -217,7 +217,7 @@ static inline uint32_t CallStep( struct MiniRV32IMAState * state, uint8_t * imag
 
 			if( addy >= MINI_RV32_RAM_SIZE-3 )
 			{
-				addy -= MINIRV32_RAM_IMAGE_OFFSET;
+				addy += MINIRV32_RAM_IMAGE_OFFSET;
 				if( addy >= 0x10000000 && addy < 0x12000000 ) 
 				{
 					// Should be stuff like SYSCON, 8250, CLNT
@@ -234,7 +234,7 @@ static inline uint32_t CallStep( struct MiniRV32IMAState * state, uint8_t * imag
 				}
 				else
 				{
-					SETCSR( mtval, addy + MINIRV32_RAM_IMAGE_OFFSET );
+					SETCSR( mtval, addy );
 					return (7+1); // Store access fault.
 				}
 			}

--- a/experiments/profiling_structure/withgoto.h
+++ b/experiments/profiling_structure/withgoto.h
@@ -200,7 +200,7 @@ MINIRV32_DECORATE int32_t MiniRV32IMAStep( struct MiniRV32IMAState * state, uint
 				rsval -= MINIRV32_RAM_IMAGE_OFFSET;
 				if( rsval >= MINI_RV32_RAM_SIZE-3 )
 				{
-					rsval -= MINIRV32_RAM_IMAGE_OFFSET;
+					rsval += MINIRV32_RAM_IMAGE_OFFSET;
 					if( rsval >= 0x10000000 && rsval < 0x12000000 )  // UART, CLNT
 					{
 						if( rsval == 0x1100bffc ) // https://chromitem-soc.readthedocs.io/en/latest/clint.html
@@ -243,7 +243,7 @@ MINIRV32_DECORATE int32_t MiniRV32IMAStep( struct MiniRV32IMAState * state, uint
 
 				if( addy >= MINI_RV32_RAM_SIZE-3 )
 				{
-					addy -= MINIRV32_RAM_IMAGE_OFFSET;
+					addy += MINIRV32_RAM_IMAGE_OFFSET;
 					if( addy >= 0x10000000 && addy < 0x12000000 ) 
 					{
 						// Should be stuff like SYSCON, 8250, CLNT
@@ -263,7 +263,7 @@ MINIRV32_DECORATE int32_t MiniRV32IMAStep( struct MiniRV32IMAState * state, uint
 					else
 					{
 						trap = (7); // Store access fault.
-						rval = addy + MINIRV32_RAM_IMAGE_OFFSET;
+						rval = addy;
 						goto hittrap;
 					}
 				}

--- a/mini-rv32ima/mini-rv32ima.h
+++ b/mini-rv32ima/mini-rv32ima.h
@@ -203,7 +203,7 @@ MINIRV32_DECORATE int32_t MiniRV32IMAStep( struct MiniRV32IMAState * state, uint
 					rsval -= MINIRV32_RAM_IMAGE_OFFSET;
 					if( rsval >= MINI_RV32_RAM_SIZE-3 )
 					{
-						rsval -= MINIRV32_RAM_IMAGE_OFFSET;
+						rsval += MINIRV32_RAM_IMAGE_OFFSET;
 						if( rsval >= 0x10000000 && rsval < 0x12000000 )  // UART, CLNT
 						{
 							if( rsval == 0x1100bffc ) // https://chromitem-soc.readthedocs.io/en/latest/clint.html
@@ -245,7 +245,7 @@ MINIRV32_DECORATE int32_t MiniRV32IMAStep( struct MiniRV32IMAState * state, uint
 
 					if( addy >= MINI_RV32_RAM_SIZE-3 )
 					{
-						addy -= MINIRV32_RAM_IMAGE_OFFSET;
+						addy += MINIRV32_RAM_IMAGE_OFFSET;
 						if( addy >= 0x10000000 && addy < 0x12000000 ) 
 						{
 							// Should be stuff like SYSCON, 8250, CLNT
@@ -264,7 +264,7 @@ MINIRV32_DECORATE int32_t MiniRV32IMAStep( struct MiniRV32IMAState * state, uint
 						else
 						{
 							trap = (7+1); // Store access fault.
-							rval = addy + MINIRV32_RAM_IMAGE_OFFSET;
+							rval = addy;
 						}
 					}
 					else


### PR DESCRIPTION
Note that this was working correctly only with default RAM offset. 
In uint32 field (x - 2^31 - 2^31) is equal x.