### PR TITLE
Fix dtb load length calculation

### DIFF
--- a/mini-rv32ima/mini-rv32ima.c
+++ b/mini-rv32ima/mini-rv32ima.c
@@ -145,7 +145,7 @@ restart:
 				long dtblen = ftell( f );
 				fseek( f, 0, SEEK_SET );
 				dtb_ptr = ram_amt - dtblen - sizeof( struct MiniRV32IMAState );
-				if( fread( ram_image + dtb_ptr, dtblen - sizeof( struct MiniRV32IMAState ), 1, f ) != 1 )
+				if( fread( ram_image + dtb_ptr, dtblen, 1, f ) != 1 )
 				{
 					fprintf( stderr, "Error: Could not open dtb \"%s\"\n", dtb_file_name );
 					return -9;


### PR DESCRIPTION
When loading a dtb file the program was subtracting sizeof( struct MiniRV32IMAState ) from the length of the file, essentially loading in a incomplete version of the dtb file.