### PR TITLE
Parameterisation of MMIO, move handlers to `.c` file.

### DIFF
--- a/mini-rv32ima/mini-rv32ima.c
+++ b/mini-rv32ima/mini-rv32ima.c
@@ -402,6 +402,15 @@ static uint32_t HandleControlStore( uint32_t addy, uint32_t val )
 		printf( "%c", val );
 		fflush( stdout );
 	}
+	else if( addy == 0x11004004 ) //CLNT
+		core->timermatchh = val;
+	else if( addy == 0x11004000 ) //CLNT
+		core->timermatchl = val;
+	else if( addy == 0x11100000 ) //SYSCON (reboot, poweroff, etc.)
+	{
+		core->pc = core->pc + 4;
+		return val; // NOTE: PC will be PC of Syscon.
+	}
 	return 0;
 }
 
@@ -413,6 +422,10 @@ static uint32_t HandleControlLoad( uint32_t addy )
 		return 0x60 | IsKBHit();
 	else if( addy == 0x10000000 && IsKBHit() )
 		return ReadKBByte();
+	else if( addy == 0x1100bffc ) // https://chromitem-soc.readthedocs.io/en/latest/clint.html
+		return core->timerh;
+	else if( addy == 0x1100bff8 )
+		return core->timerl;
 	return 0;
 }
 

--- a/mini-rv32ima/mini-rv32ima.h
+++ b/mini-rv32ima/mini-rv32ima.h
@@ -33,6 +33,14 @@
 	#define MINIRV32_RAM_IMAGE_OFFSET  0x80000000
 #endif
 
+#ifndef MINIRV32_MMIO_START
+	#define MINIRV32_MMIO_START  0x10000000
+#endif
+
+#ifndef MINIRV32_MMIO_END
+	#define MINIRV32_MMIO_END  0x12000000
+#endif
+
 #ifndef MINIRV32_POSTEXEC
 	#define MINIRV32_POSTEXEC(...);
 #endif
@@ -224,14 +232,9 @@ MINIRV32_STEPPROTO
 					if( rsval >= MINI_RV32_RAM_SIZE-3 )
 					{
 						rsval += MINIRV32_RAM_IMAGE_OFFSET;
-						if( rsval >= 0x10000000 && rsval < 0x12000000 )  // UART, CLNT
+						if( rsval >= MINIRV32_MMIO_START && rsval < MINIRV32_MMIO_END )  // UART, CLNT
 						{
-							if( rsval == 0x1100bffc ) // https://chromitem-soc.readthedocs.io/en/latest/clint.html
-								rval = CSR( timerh );
-							else if( rsval == 0x1100bff8 )
-								rval = CSR( timerl );
-							else
-								MINIRV32_HANDLE_MEM_LOAD_CONTROL( rsval, rval );
+							MINIRV32_HANDLE_MEM_LOAD_CONTROL( rsval, rval );
 						}
 						else
 						{
@@ -266,20 +269,9 @@ MINIRV32_STEPPROTO
 					if( addy >= MINI_RV32_RAM_SIZE-3 )
 					{
 						addy += MINIRV32_RAM_IMAGE_OFFSET;
-						if( addy >= 0x10000000 && addy < 0x12000000 )
+						if( addy >= MINIRV32_MMIO_START && addy < MINIRV32_MMIO_END )
 						{
-							// Should be stuff like SYSCON, 8250, CLNT
-							if( addy == 0x11004004 ) //CLNT
-								CSR( timermatchh ) = rs2;
-							else if( addy == 0x11004000 ) //CLNT
-								CSR( timermatchl ) = rs2;
-							else if( addy == 0x11100000 ) //SYSCON (reboot, poweroff, etc.)
-							{
-								SETCSR( pc, pc + 4 );
-								return rs2; // NOTE: PC will be PC of Syscon.
-							}
-							else
-								MINIRV32_HANDLE_MEM_STORE_CONTROL( addy, rs2 );
+							MINIRV32_HANDLE_MEM_STORE_CONTROL( addy, rs2 );
 						}
 						else
 						{

--- a/mini-rv32ima/mini-rv32ima.h
+++ b/mini-rv32ima/mini-rv32ima.h
@@ -33,12 +33,8 @@
 	#define MINIRV32_RAM_IMAGE_OFFSET  0x80000000
 #endif
 
-#ifndef MINIRV32_MMIO_START
-	#define MINIRV32_MMIO_START  0x10000000
-#endif
-
-#ifndef MINIRV32_MMIO_END
-	#define MINIRV32_MMIO_END  0x12000000
+#ifndef MINIRV32_MMIO_RANGE
+	#define MINIRV32_MMIO_RANGE(n)  (0x10000000 <= (n) && (n) < 0x12000000)
 #endif
 
 #ifndef MINIRV32_POSTEXEC
@@ -232,7 +228,7 @@ MINIRV32_STEPPROTO
 					if( rsval >= MINI_RV32_RAM_SIZE-3 )
 					{
 						rsval += MINIRV32_RAM_IMAGE_OFFSET;
-						if( rsval >= MINIRV32_MMIO_START && rsval < MINIRV32_MMIO_END )  // UART, CLNT
+						if( MINIRV32_MMIO_RANGE( rsval ) )  // UART, CLNT
 						{
 							MINIRV32_HANDLE_MEM_LOAD_CONTROL( rsval, rval );
 						}
@@ -269,7 +265,7 @@ MINIRV32_STEPPROTO
 					if( addy >= MINI_RV32_RAM_SIZE-3 )
 					{
 						addy += MINIRV32_RAM_IMAGE_OFFSET;
-						if( addy >= MINIRV32_MMIO_START && addy < MINIRV32_MMIO_END )
+						if( MINIRV32_MMIO_RANGE( addy ) )
 						{
 							MINIRV32_HANDLE_MEM_STORE_CONTROL( addy, rs2 );
 						}


### PR DESCRIPTION
This PR moves the existing MMIO stores/loads to the `mini-rv32ima.c` file, allowing for adaptation in environments where concepts such as `SYSCON` don't exist. Use of the VM for embedded scripting, for instance.

Also parameterised the MMIO range so they can be overridden.

Ran through `make everything`, `make testkern`, `make testdlimage`, `make testbare`, and `make testdoom` -- things seem to still function correctly.