### PR TITLE
[RFC] Add support for RV64 extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,77 @@
+# Build outputs
+buildroot/
+buildroot/output/
+buildroot/dl/
+buildroot/.config
+
+# mini-rv32ima generated artifacts
+mini-rv32ima/mini-rv32ima
+mini-rv32ima/mini-rv32ima.flt
+mini-rv32ima/mini-rv32ima.tiny
+mini-rv32ima/bintoh
+mini-rv32ima/bintoh.c
+mini-rv32ima/DownloadedImage
+mini-rv32ima/*.zip
+mini-rv32ima/*.dtb
+mini-rv32ima/*.log
+mini-rv32ima/wget-log
+mini-rv32ima/*~
+mini-rv32ima/*.o
+
+# Baremetal build outputs
+baremetal/*.elf
+baremetal/*.bin
+baremetal/*.debug.txt
+baremetal/*~
+
+# Package build outputs
+packages/**/*.o
+packages/**/*.bin
+packages/**/*.gdb
+packages/**/*.S
+packages/**/*~
+
+# Package downloads and extracted source
+packages/coremark/coremark
+packages/coremark/coremark-1.01/
+packages/coremark/v1.01.zip
+
+# hello_linux outputs
+hello_linux/hello_linux
+hello_linux/*.S
+hello_linux/pi
+hello_linux/*.gdb
+hello_linux/*~
+
+# riscv-tests harness downloads and builds (but NOT the Makefile/README)
+riscv-tests-harness/riscv-tests/
+
+# EMU / QEMU / generated state
+*.img
+*.iso
+*.dtb
+*.dts
+*.flt
+*.bin
+*.elf
+*.o
+*.map
+*.tmp
+*.log
+*.dump
+*.gdb
+
+# Editor directories and swap files
+.vscode/
+*.swp
+*~
+.DS_Store
+.idea/
+
+# Python
+__pycache__/
+*.py[cod]
+
+# Misc
+tags
+*tags

--- a/Makefile
+++ b/Makefile
@@ -59,5 +59,4 @@ dtbextract : $(DTC)
 	$(DTC) -I dtb -O dts -o dtb.dts dtb.dtb
 
 tests :
-	git clone https://github.com/riscv-software-src/riscv-tests
-	./configure --prefix=
+	make -C riscv-tests-harness run

--- a/mini-rv32ima/mini-rv32ima.h
+++ b/mini-rv32ima/mini-rv32ima.h
@@ -3,6 +3,7 @@
 #ifndef _MINI_RV32IMAH_H
 #define _MINI_RV32IMAH_H
 
+#include "spec.h"
 /**
     To use mini-rv32ima.h for the bare minimum, the following:
 
@@ -30,7 +31,7 @@
 #endif
 
 #ifndef MINIRV32_RAM_IMAGE_OFFSET
-	#define MINIRV32_RAM_IMAGE_OFFSET  0x80000000
+	#define MINIRV32_RAM_IMAGE_OFFSET  0x80000000UL
 #endif
 
 #ifndef MINIRV32_MMIO_RANGE
@@ -58,12 +59,15 @@
 #endif
 
 #ifndef MINIRV32_CUSTOM_MEMORY_BUS
+	#define MINIRV32_STORE8( ofs, val ) *(uint64_t*)(image + ofs) = val
 	#define MINIRV32_STORE4( ofs, val ) *(uint32_t*)(image + ofs) = val
 	#define MINIRV32_STORE2( ofs, val ) *(uint16_t*)(image + ofs) = val
 	#define MINIRV32_STORE1( ofs, val ) *(uint8_t*)(image + ofs) = val
+	#define MINIRV32_LOAD8( ofs ) *(uint64_t*)(image + ofs)
 	#define MINIRV32_LOAD4( ofs ) *(uint32_t*)(image + ofs)
 	#define MINIRV32_LOAD2( ofs ) *(uint16_t*)(image + ofs)
 	#define MINIRV32_LOAD1( ofs ) *(uint8_t*)(image + ofs)
+	#define MINIRV32_LOAD4_SIGNED( ofs ) *(int32_t*)(image + ofs)
 	#define MINIRV32_LOAD2_SIGNED( ofs ) *(int16_t*)(image + ofs)
 	#define MINIRV32_LOAD1_SIGNED( ofs ) *(int8_t*)(image + ofs)
 #endif
@@ -74,32 +78,44 @@
 // We're going to try to keep the full processor state to 12 x uint4.
 struct MiniRV32IMAState
 {
-	uint32_t regs[32];
+	xlen_t regs[32];
 
-	uint32_t pc;
-	uint32_t mstatus;
+	xlen_t pc;
+	xlen_t mstatus;
+#if (XLEN == 64)
+	uint64_t cycle
+#else
 	uint32_t cyclel;
 	uint32_t cycleh;
+#endif
 
+#if (XLEN == 64)
+	uint64_t timer;
+#else
 	uint32_t timerl;
 	uint32_t timerh;
+#endif
+#if (XLEN == 64)
+	uint64_t timermatch
+#else
 	uint32_t timermatchl;
 	uint32_t timermatchh;
+#endif
 
-	uint32_t mscratch;
-	uint32_t mtvec;
-	uint32_t mie;
-	uint32_t mip;
+	xlen_t mscratch;
+	xlen_t mtvec;
+	xlen_t mie;
+	xlen_t mip;
 
-	uint32_t mepc;
-	uint32_t mtval;
-	uint32_t mcause;
+	xlen_t mepc;
+	xlen_t mtval;
+	xlen_t mcause;
 
 	// Note: only a few bits are used.  (Machine = 3, User = 0)
 	// Bits 0..1 = privilege.
 	// Bit 2 = WFI (Wait for interrupt)
 	// Bit 3+ = Load/Store reservation LSBs.
-	uint32_t extraflags;
+	xlen_t extraflags;
 };
 
 #ifndef MINIRV32_STEPPROTO
@@ -121,108 +137,112 @@ MINIRV32_DECORATE int32_t MiniRV32IMAStep( struct MiniRV32IMAState * state, uint
 MINIRV32_STEPPROTO
 #endif
 {
+#if (XLEN == 64)
+	CSR( timer ) = CSR( timer ) + elapsedUs;
+#else
 	uint32_t new_timer = CSR( timerl ) + elapsedUs;
 	if( new_timer < CSR( timerl ) ) CSR( timerh )++;
 	CSR( timerl ) = new_timer;
+#endif
 
 	// Handle Timer interrupt.
+#if (XLEN == 64)
+	if( ( CSR( timer ) > CSR( timermatch ) ) && ( CSR( timermatch ) ) )
+#else
 	if( ( CSR( timerh ) > CSR( timermatchh ) || ( CSR( timerh ) == CSR( timermatchh ) && CSR( timerl ) > CSR( timermatchl ) ) ) && ( CSR( timermatchh ) || CSR( timermatchl ) ) )
+#endif
 	{
-		CSR( extraflags ) &= ~4; // Clear WFI
-		CSR( mip ) |= 1<<7; //MTIP of MIP // https://stackoverflow.com/a/61916199/2926815  Fire interrupt.
+		CSR( extraflags ) &= ~(1UL << EXTRAFLAGS_WFI_BIT); // Clear WFI
+		CSR( mip ) |= (1UL << MIP_MTIP_BIT); //MTIP of MIP // https://stackoverflow.com/a/61916199/2926815  Fire interrupt.
 	}
 	else
-		CSR( mip ) &= ~(1<<7);
+		CSR( mip ) &= ~(1UL << MIP_MTIP_BIT);
 
 	// If WFI, don't run processor.
-	if( CSR( extraflags ) & 4 )
+	if( CSR( extraflags ) & (1UL << EXTRAFLAGS_WFI_BIT) )
 		return 1;
 
-	uint32_t trap = 0;
-	uint32_t rval = 0;
-	uint32_t pc = CSR( pc );
+	xlen_t trap = 0;
+	xlen_t rval = 0;
+	xlen_t pc = CSR( pc );
+#if (XLEN == 64)
+	uint64_t cycle = CSR( cycle );
+#else
 	uint32_t cycle = CSR( cyclel );
+#endif
 
-	if( ( CSR( mip ) & (1<<7) ) && ( CSR( mie ) & (1<<7) /*mtie*/ ) && ( CSR( mstatus ) & 0x8 /*mie*/) )
+	if( ( CSR( mip ) & (1UL<<MIP_MTIP_BIT) ) && ( CSR( mie ) & (1UL<<MIP_MTIP_BIT) /*mtie*/ ) && ( CSR( mstatus ) & (1UL<<MSTATUS_MIE_BIT) /*mie*/) )
 	{
 		// Timer interrupt.
-		trap = 0x80000007;
+		trap = (1UL<<MCAUSE_INTERRUPT_BIT)|(MIP_MTIP_BIT);
 		pc -= 4;
 	}
 	else // No timer interrupt?  Execute a bunch of instructions.
 	for( int icount = 0; icount < count; icount++ )
 	{
-		uint32_t ir = 0;
+		xlen_t ir = 0;
 		rval = 0;
 		cycle++;
-		uint32_t ofs_pc = pc - MINIRV32_RAM_IMAGE_OFFSET;
+		xlen_t ofs_pc = pc - MINIRV32_RAM_IMAGE_OFFSET;
 
 		if( ofs_pc >= MINI_RV32_RAM_SIZE )
 		{
-			trap = 1 + 1;  // Handle access violation on instruction read.
+			trap = 1 + MCAUSE_INSTRUCTION_ACCESS_FAULT;  // Handle access violation on instruction read.
 			break;
 		}
 		else if( ofs_pc & 3 )
 		{
-			trap = 1 + 0;  //Handle PC-misaligned access
+			trap = 1 + MCAUSE_INSTRUCTION_ADDR_MISALIGNED;  //Handle PC-misaligned access
 			break;
 		}
 		else
 		{
 			ir = MINIRV32_LOAD4( ofs_pc );
-			uint32_t rdid = (ir >> 7) & 0x1f;
+			uint32_t rdid = GET_RD( ir );
 
-			switch( ir & 0x7f )
+			switch( GET_OPCODE( ir ) )
 			{
-				case 0x37: // LUI (0b0110111)
-					rval = ( ir & 0xfffff000 );
+				case OPCODE_LUI: // LUI (0b0110111)
+					rval = UTYPE_IMM( ir );
 					break;
-				case 0x17: // AUIPC (0b0010111)
-					rval = pc + ( ir & 0xfffff000 );
+				case OPCODE_AUIPC: // AUIPC (0b0010111)
+					rval = pc + UTYPE_IMM( ir );
 					break;
-				case 0x6F: // JAL (0b1101111)
+				case OPCODE_JAL: // JAL (0b1101111)
 				{
-					int32_t reladdy = ((ir & 0x80000000)>>11) | ((ir & 0x7fe00000)>>20) | ((ir & 0x00100000)>>9) | ((ir&0x000ff000));
-					if( reladdy & 0x00100000 ) reladdy |= 0xffe00000; // Sign extension.
 					rval = pc + 4;
-					pc = pc + reladdy - 4;
+					pc = pc + JTYPE_IMM( ir ) - 4;
 					break;
 				}
-				case 0x67: // JALR (0b1100111)
+				case OPCODE_JALR: // JALR (0b1100111)
 				{
-					uint32_t imm = ir >> 20;
-					int32_t imm_se = imm | (( imm & 0x800 )?0xfffff000:0);
 					rval = pc + 4;
-					pc = ( (REG( (ir >> 15) & 0x1f ) + imm_se) & ~1) - 4;
+					pc = (REG( GET_RS1( ir ) ) + ITYPE_IMM( ir )) - 4 /* pc is incremented by 4 later */;
 					break;
 				}
-				case 0x63: // Branch (0b1100011)
+				case OPCODE_BRANCH: // Branch (0b1100011)
 				{
-					uint32_t immm4 = ((ir & 0xf00)>>7) | ((ir & 0x7e000000)>>20) | ((ir & 0x80) << 4) | ((ir >> 31)<<12);
-					if( immm4 & 0x1000 ) immm4 |= 0xffffe000;
-					int32_t rs1 = REG((ir >> 15) & 0x1f);
-					int32_t rs2 = REG((ir >> 20) & 0x1f);
-					immm4 = pc + immm4 - 4;
+					sxlen_t rs1 = REG( GET_RS1( ir ) );
+					sxlen_t rs2 = REG( GET_RS2( ir ) );
+					xlen_t immm4 = pc + BTYPE_IMM( ir ) - 4;
 					rdid = 0;
-					switch( ( ir >> 12 ) & 0x7 )
+					switch( GET_FUNC3(ir) )
 					{
 						// BEQ, BNE, BLT, BGE, BLTU, BGEU
 						case 0: if( rs1 == rs2 ) pc = immm4; break;
 						case 1: if( rs1 != rs2 ) pc = immm4; break;
 						case 4: if( rs1 < rs2 ) pc = immm4; break;
 						case 5: if( rs1 >= rs2 ) pc = immm4; break; //BGE
-						case 6: if( (uint32_t)rs1 < (uint32_t)rs2 ) pc = immm4; break;   //BLTU
-						case 7: if( (uint32_t)rs1 >= (uint32_t)rs2 ) pc = immm4; break;  //BGEU
-						default: trap = (2+1);
+						case 6: if( (xlen_t)rs1 < (xlen_t)rs2 ) pc = immm4; break;   //BLTU
+						case 7: if( (xlen_t)rs1 >= (xlen_t)rs2 ) pc = immm4; break;  //BGEU
+						default: trap = (1+MCAUSE_ILLEGAL_INSTRUCTION);
 					}
 					break;
 				}
-				case 0x03: // Load (0b0000011)
+				case OPCODE_LOAD: // Load (0b0000011)
 				{
-					uint32_t rs1 = REG((ir >> 15) & 0x1f);
-					uint32_t imm = ir >> 20;
-					int32_t imm_se = imm | (( imm & 0x800 )?0xfffff000:0);
-					uint32_t rsval = rs1 + imm_se;
+					xlen_t rs1 = REG( GET_RS1( ir ) );
+					xlen_t rsval = rs1 + ITYPE_IMM( ir );
 
 					rsval -= MINIRV32_RAM_IMAGE_OFFSET;
 					if( rsval >= MINI_RV32_RAM_SIZE-3 )
@@ -234,31 +254,34 @@ MINIRV32_STEPPROTO
 						}
 						else
 						{
-							trap = (5+1);
+							trap = (1+MCAUSE_LOAD_ACCESS_FAULT);
 							rval = rsval;
 						}
 					}
 					else
 					{
-						switch( ( ir >> 12 ) & 0x7 )
+						switch( GET_FUNC3(ir) )
 						{
-							//LB, LH, LW, LBU, LHU
+							//LB, LH, LW, LD, LBU, LHU, LWU
 							case 0: rval = MINIRV32_LOAD1_SIGNED( rsval ); break;
 							case 1: rval = MINIRV32_LOAD2_SIGNED( rsval ); break;
-							case 2: rval = MINIRV32_LOAD4( rsval ); break;
+							case 2: rval = MINIRV32_LOAD4_SIGNED( rsval ); break;
 							case 4: rval = MINIRV32_LOAD1( rsval ); break;
 							case 5: rval = MINIRV32_LOAD2( rsval ); break;
-							default: trap = (2+1);
+#if (XLEN == 64)
+							case 3: rval = MINIRV32_LOAD8( rsval ); break;
+							case 6: rval = MINIRV32_LOAD4( rsval ); break;
+#endif
+							default: trap = (1+MCAUSE_ILLEGAL_INSTRUCTION);
 						}
 					}
 					break;
 				}
-				case 0x23: // Store 0b0100011
+				case OPCODE_STORE: // Store 0b0100011
 				{
-					uint32_t rs1 = REG((ir >> 15) & 0x1f);
-					uint32_t rs2 = REG((ir >> 20) & 0x1f);
-					uint32_t addy = ( ( ir >> 7 ) & 0x1f ) | ( ( ir & 0xfe000000 ) >> 20 );
-					if( addy & 0x800 ) addy |= 0xfffff000;
+					xlen_t rs1 = REG( GET_RS1(ir) );
+					xlen_t rs2 = REG( GET_RS2(ir) );
+					xlen_t addy = STYPE_IMM(ir);
 					addy += rs1 - MINIRV32_RAM_IMAGE_OFFSET;
 					rdid = 0;
 
@@ -271,78 +294,114 @@ MINIRV32_STEPPROTO
 						}
 						else
 						{
-							trap = (7+1); // Store access fault.
+							trap = (1+MCAUSE_STORE_ACCESS_FAULT); // Store access fault.
 							rval = addy;
 						}
 					}
 					else
 					{
-						switch( ( ir >> 12 ) & 0x7 )
+						switch( GET_FUNC3(ir) )
 						{
-							//SB, SH, SW
+							//SB, SH, SW, SD
 							case 0: MINIRV32_STORE1( addy, rs2 ); break;
 							case 1: MINIRV32_STORE2( addy, rs2 ); break;
 							case 2: MINIRV32_STORE4( addy, rs2 ); break;
-							default: trap = (2+1);
+#if (XLEN==64)
+							case 3: MINIRV32_STORE8( addy, rs2 ); break;
+#endif
+							default: trap = (1+MCAUSE_ILLEGAL_INSTRUCTION);
 						}
 					}
 					break;
 				}
-				case 0x13: // Op-immediate 0b0010011
-				case 0x33: // Op           0b0110011
+				case OPCODE_OP_IMM: // Op-immediate 0b0010011
+				case OPCODE_OP: // Op           0b0110011
 				{
-					uint32_t imm = ir >> 20;
-					imm = imm | (( imm & 0x800 )?0xfffff000:0);
-					uint32_t rs1 = REG((ir >> 15) & 0x1f);
-					uint32_t is_reg = !!( ir & 0x20 );
-					uint32_t rs2 = is_reg ? REG(imm & 0x1f) : imm;
+					xlen_t imm = ITYPE_IMM(ir);
+					xlen_t rs1 = REG(GET_RS1(ir));
+					xlen_t is_reg = !!( ir & 0x20 );
+					xlen_t rs2 = is_reg ? REG(GET_RS2(ir)) : imm;
 
-					if( is_reg && ( ir & 0x02000000 ) )
+					if( is_reg && IS_FUNC7_MUL(ir) )
 					{
-						switch( (ir>>12)&7 ) //0x02000000 = RV32M
+						switch( GET_FUNC3(ir) ) //0x02000000 = RV32M
 						{
 							case 0: rval = rs1 * rs2; break; // MUL
 #ifndef CUSTOM_MULH // If compiling on a system that doesn't natively, or via libgcc support 64-bit math.
-							case 1: rval = ((int64_t)((int32_t)rs1) * (int64_t)((int32_t)rs2)) >> 32; break; // MULH
-							case 2: rval = ((int64_t)((int32_t)rs1) * (uint64_t)rs2) >> 32; break; // MULHSU
-							case 3: rval = ((uint64_t)rs1 * (uint64_t)rs2) >> 32; break; // MULHU
+							case 1: rval = ((sxlen2_t)((sxlen_t)rs1) * (sxlen2_t)((sxlen_t)rs2)) >> XLEN; break; // MULH
+							case 2: rval = ((sxlen2_t)((sxlen_t)rs1) * (xlen2_t)rs2) >> XLEN; break; // MULHSU
+							case 3: rval = ((xlen2_t)rs1 * (xlen2_t)rs2) >> XLEN; break; // MULHU
 #else
 							CUSTOM_MULH
 #endif
-							case 4: if( rs2 == 0 ) rval = -1; else rval = ((int32_t)rs1 == INT32_MIN && (int32_t)rs2 == -1) ? rs1 : ((int32_t)rs1 / (int32_t)rs2); break; // DIV
-							case 5: if( rs2 == 0 ) rval = 0xffffffff; else rval = rs1 / rs2; break; // DIVU
-							case 6: if( rs2 == 0 ) rval = rs1; else rval = ((int32_t)rs1 == INT32_MIN && (int32_t)rs2 == -1) ? 0 : ((uint32_t)((int32_t)rs1 % (int32_t)rs2)); break; // REM
+							case 4: if( rs2 == 0 ) rval = -1L; else rval = ((sxlen_t)rs1 == SXLEN_MIN && (sxlen_t)rs2 == -1L) ? rs1 : ((sxlen_t)rs1 / (sxlen_t)rs2); break; // DIV
+							case 5: if( rs2 == 0 ) rval = XLEN_MAX; else rval = rs1 / rs2; break; // DIVU
+							case 6: if( rs2 == 0 ) rval = rs1; else rval = ((sxlen_t)rs1 == SXLEN_MIN && (sxlen_t)rs2 == -1L) ? 0 : ((xlen_t)((sxlen_t)rs1 % (sxlen_t)rs2)); break; // REM
 							case 7: if( rs2 == 0 ) rval = rs1; else rval = rs1 % rs2; break; // REMU
 						}
 					}
 					else
 					{
-						switch( (ir>>12)&7 ) // These could be either op-immediate or op commands.  Be careful.
+						switch( GET_FUNC3(ir) ) // These could be either op-immediate or op commands.  Be careful.
 						{
-							case 0: rval = (is_reg && (ir & 0x40000000) ) ? ( rs1 - rs2 ) : ( rs1 + rs2 ); break; 
-							case 1: rval = rs1 << (rs2 & 0x1F); break;
-							case 2: rval = (int32_t)rs1 < (int32_t)rs2; break;
+							case 0: rval = (is_reg && IS_FUNC7_SUB(ir) ) ? ( rs1 - rs2 ) : ( rs1 + rs2 ); break; 
+							case 1: rval = rs1 << (rs2 & SHIFT_MASK); break;
+							case 2: rval = (sxlen_t)rs1 < (sxlen_t)rs2; break;
 							case 3: rval = rs1 < rs2; break;
 							case 4: rval = rs1 ^ rs2; break;
-							case 5: rval = (ir & 0x40000000 ) ? ( ((int32_t)rs1) >> (rs2 & 0x1F) ) : ( rs1 >> (rs2 & 0x1F) ); break;
+							case 5: rval = IS_FUNC7_SRA(ir) ? ( ((sxlen_t)rs1) >> (rs2 & SHIFT_MASK) ) : ( rs1 >> (rs2 & SHIFT_MASK) ); break;
 							case 6: rval = rs1 | rs2; break;
 							case 7: rval = rs1 & rs2; break;
 						}
 					}
 					break;
 				}
-				case 0x0f: // 0b0001111
+#if (XLEN==64)
+				case OPCODE_OP_IMM_32: // Op-32-immediate 0b0011011
+				case OPCODE_OP_32: // Op-32          0b0111011
+				{
+					xlen_t imm = ITYPE_IMM(ir);
+					xlen_t rs1 = REG(GET_RS1(ir));
+					xlen_t is_reg = !!( ir & 0x20 );
+					xlen_t rs2 = is_reg ? REG(GET_RS2(ir)) : imm;
+
+					if( is_reg && IS_FUNC7_MUL(ir) )
+					{
+						switch( GET_FUNC3(ir) ) //0x02000000 = RV32M
+						{
+							case 0: rval = (int32_t) (((int32_t) rs1) * ((int32_t) rs2)); break; // MULW
+							case 4: if( ((int32_t) rs2) == 0 ) rval = -1; else rval = ((int32_t)rs1 == INT32_MIN && (int32_t)rs2 == -1) ? ((int32_t)rs1) : ((int32_t)rs1 / (int32_t)rs2); break; // DIVW
+							case 5: if( ((uint32_t)rs2) == 0 ) rval = UINT64_MAX; else rval = (int32_t)(((uint32_t)rs1) / ((uint32_t)rs2)); break; // DIVUW
+							case 6: if( ((int32_t) rs2) == 0 ) rval = ((int32_t)rs1); else rval = ((int32_t)rs1 == INT32_MIN && (int32_t)rs2 == -1) ? 0 : ((int32_t)((uint32_t)((int32_t)rs1 % (int32_t)rs2))); break; // REMW
+							case 7: if( ((uint32_t)rs2) == 0 ) rval = ((int32_t)rs1); else rval = (int32_t)(((uint32_t)rs1) % ((uint32_t)rs2)); break; // REMUW
+							default: trap = 1+MCAUSE_ILLEGAL_INSTRUCTION;
+						}
+					}
+					else
+					{
+						switch( GET_FUNC3(ir) ) // These could be either op-immediate or op commands.  Be careful.
+						{
+							case 0: rval = (int32_t)((is_reg && IS_FUNC7_SUB(ir) ) ? ( rs1 - rs2 ) : ( rs1 + rs2 )); break; 
+							case 1: rval = (int32_t)(rs1 << (rs2 & 0x1F)); break;
+							case 5: rval = (int32_t)(IS_FUNC7_SRA(ir) ? ( ((int32_t)rs1) >> (rs2 & 0x1F) ) : ( rs1 >> (rs2 & 0x1F) )); break;
+							default: trap = 1+MCAUSE_ILLEGAL_INSTRUCTION;
+						}
+					}
+					break;
+				}
+#endif
+				case OPCODE_MISC_MEM: // 0b0001111
 					rdid = 0;   // fencetype = (ir >> 12) & 0b111; We ignore fences in this impl.
 					break;
-				case 0x73: // Zifencei+Zicsr  (0b1110011)
+				case OPCODE_SYSTEM: // Zifencei+Zicsr  (0b1110011)
 				{
-					uint32_t csrno = ir >> 20;
-					uint32_t microop = ( ir >> 12 ) & 0x7;
+					uint32_t csrno = GET_CSR_ADDR(ir);
+					uint32_t microop = GET_FUNC3(ir);
 					if( (microop & 3) ) // It's a Zicsr function.
 					{
-						int rs1imm = (ir >> 15) & 0x1f;
-						uint32_t rs1 = REG(rs1imm);
-						uint32_t writeval = rs1;
+						int rs1imm = GET_RS1(ir);
+						xlen_t rs1 = REG(rs1imm);
+						xlen_t writeval = rs1;
 
 						// https://raw.githubusercontent.com/riscv/virtual-memory/main/specs/663-Svpbmt.pdf
 						// Generally, support for Zicsr
@@ -358,7 +417,7 @@ MINIRV32_STEPPROTO
 						case 0x342: rval = CSR( mcause ); break;
 						case 0x343: rval = CSR( mtval ); break;
 						case 0xf11: rval = 0xff0ff0ff; break; //mvendorid
-						case 0x301: rval = 0x40401101; break; //misa (XLEN=32, IMA+X)
+						case 0x301: rval = MISA_READ; break; //misa (XLEN=32, IMA+X)
 						//case 0x3B0: rval = 0; break; //pmpaddr0
 						//case 0x3a0: rval = 0; break; //pmpcfg0
 						//case 0xf12: rval = 0x00000000; break; //marchid
@@ -409,42 +468,41 @@ MINIRV32_STEPPROTO
 							//https://raw.githubusercontent.com/riscv/virtual-memory/main/specs/663-Svpbmt.pdf
 							//Table 7.6. MRET then in mstatus/mstatush sets MPV=0, MPP=0, MIE=MPIE, and MPIE=1. La
 							// Should also update mstatus to reflect correct mode.
-							uint32_t startmstatus = CSR( mstatus );
-							uint32_t startextraflags = CSR( extraflags );
-							SETCSR( mstatus , (( startmstatus & 0x80) >> 4) | ((startextraflags&3) << 11) | 0x80 );
-							SETCSR( extraflags, (startextraflags & ~3) | ((startmstatus >> 11) & 3) );
+							xlen_t startmstatus = CSR( mstatus );
+							xlen_t startextraflags = CSR( extraflags );
+							SETCSR( mstatus , (( startmstatus & (1UL<<MSTATUS_MPIE_BIT)) >> (MSTATUS_MPIE_BIT-MSTATUS_MIE_BIT)) | ((startextraflags&3) << MSTATUS_MPP_START_BIT) | (1UL<<MSTATUS_MPIE_BIT) );
+							SETCSR( extraflags, (startextraflags & ~3) | ((startmstatus >> MSTATUS_MPP_START_BIT) & 3) );
 							pc = CSR( mepc ) -4;
 						} else {
 							switch (csrno) {
 							case 0:
-								trap = ( CSR( extraflags ) & 3) ? (11+1) : (8+1); // ECALL; 8 = "Environment call from U-mode"; 11 = "Environment call from M-mode"
+								trap = ( CSR( extraflags ) & 3) ? (1+MCAUSE_ECALL_FROM_M) : (1+MCAUSE_ECALL_FROM_U); // ECALL; 8 = "Environment call from U-mode"; 11 = "Environment call from M-mode"
 								break;
 							case 1:
-								trap = (3+1); break; // EBREAK 3 = "Breakpoint"
+								trap = (1+MCAUSE_BREAKPOINT); break; // EBREAK 3 = "Breakpoint"
 							case 0x105: //WFI (Wait for interrupts)
-								CSR( mstatus ) |= 8;    //Enable interrupts
+								CSR( mstatus ) |= (1UL << MSTATUS_MIE_BIT);    //Enable interrupts
 								CSR( extraflags ) |= 4; //Infor environment we want to go to sleep.
 
-								if( CSR( cyclel ) > cycle ) CSR( cycleh )++;
-								SETCSR( cyclel, cycle );
+								SET_MCYCLE( cycle );
 
 								MINIRV32_POSTEXEC( pc, ir, trap );
 
 								SETCSR( pc, pc + 4 );
 								return 1;
 							default:
-								trap = (2+1); break; // Illegal opcode.
+								trap = (1+MCAUSE_ILLEGAL_INSTRUCTION); break; // Illegal opcode.
 							}
 						}
 					}
 					else
-						trap = (2+1); 				// Note micrrop 0b100 == undefined.
+						trap = (1+MCAUSE_ILLEGAL_INSTRUCTION); 				// Note micrrop 0b100 == undefined.
 					break;
 				}
 				case 0x2f: // RV32A (0b00101111)
 				{
-					uint32_t rs1 = REG((ir >> 15) & 0x1f);
-					uint32_t rs2 = REG((ir >> 20) & 0x1f);
+					xlen_t rs1 = REG(GET_RS1(ir));
+					xlen_t rs2 = REG(GET_RS2(ir));
 					uint32_t irmid = ( ir>>27 ) & 0x1f;
 
 					rs1 -= MINIRV32_RAM_IMAGE_OFFSET;
@@ -453,9 +511,41 @@ MINIRV32_STEPPROTO
 
 					if( rs1 >= MINI_RV32_RAM_SIZE-3 )
 					{
-						trap = (7+1); //Store/AMO access fault
+						trap = (1+MCAUSE_STORE_ACCESS_FAULT); //Store/AMO access fault
 						rval = rs1 + MINIRV32_RAM_IMAGE_OFFSET;
 					}
+#if (XLEN == 64)
+					elif (GET_FUNC3(ir) == 0b011)
+					{
+						rval = MINIRV32_LOAD8( rs1 );
+
+						// Referenced a little bit of https://github.com/franzflasch/riscv_em/blob/master/src/core/core.c
+						uint32_t dowrite = 1;
+						switch( irmid )
+						{
+							case 2: //LR.D (0b00010)
+								dowrite = 0;
+								CSR( extraflags ) = (CSR( extraflags ) & (~RESERVATION_MASK)) | (rs1&RESERVATION_MASK);
+								break;
+							case 3:  //SC.D (0b00011) (Make sure we have a slot, and, it's valid)
+								rval = ( (CSR( extraflags ) & RESERVATION_MASK) != ( rs1 & RESERVATION_MASK ) );  // Validate that our reservation slot is OK.
+								(CSR( extraflags ) &= (~RESERVATION_MASK)); // reservation set in invalidated after each SC.D
+								dowrite = !rval; // Only write if slot is valid.
+								break;
+							case 1: break; //AMOSWAP.D (0b00001)
+							case 0: rs2 += rval; break; //AMOADD.D (0b00000)
+							case 4: rs2 ^= rval; break; //AMOXOR.D (0b00100)
+							case 12: rs2 &= rval; break; //AMOAND.D (0b01100)
+							case 8: rs2 |= rval; break; //AMOOR.D (0b01000)
+							case 16: rs2 = ((int64_t)rs2<(int64_t)rval)?rs2:rval; break; //AMOMIN.D (0b10000)
+							case 20: rs2 = ((int64_t)rs2>(int64_t)rval)?rs2:rval; break; //AMOMAX.D (0b10100)
+							case 24: rs2 = (rs2<rval)?rs2:rval; break; //AMOMINU.D (0b11000)
+							case 28: rs2 = (rs2>rval)?rs2:rval; break; //AMOMAXU.D (0b11100)
+							default: trap = (1+MCAUSE_ILLEGAL_INSTRUCTION); dowrite = 0; break; //Not supported.
+						}
+						if( dowrite ) MINIRV32_STORE8( rs1, rs2 );
+					}
+#endif
 					else
 					{
 						rval = MINIRV32_LOAD4( rs1 );
@@ -466,10 +556,11 @@ MINIRV32_STEPPROTO
 						{
 							case 2: //LR.W (0b00010)
 								dowrite = 0;
-								CSR( extraflags ) = (CSR( extraflags ) & 0x07) | (rs1<<3);
+								CSR( extraflags ) = (CSR( extraflags ) & (~RESERVATION_MASK)) | (rs1&RESERVATION_MASK);
 								break;
 							case 3:  //SC.W (0b00011) (Make sure we have a slot, and, it's valid)
-								rval = ( CSR( extraflags ) >> 3 != ( rs1 & 0x1fffffff ) );  // Validate that our reservation slot is OK.
+								rval = ( (CSR( extraflags ) & RESERVATION_MASK) != ( rs1 & RESERVATION_MASK ) );  // Validate that our reservation slot is OK.
+								(CSR( extraflags ) &= (~RESERVATION_MASK)); // reservation set in invalidated after each SC.W
 								dowrite = !rval; // Only write if slot is valid.
 								break;
 							case 1: break; //AMOSWAP.W (0b00001)
@@ -479,15 +570,15 @@ MINIRV32_STEPPROTO
 							case 8: rs2 |= rval; break; //AMOOR.W (0b01000)
 							case 16: rs2 = ((int32_t)rs2<(int32_t)rval)?rs2:rval; break; //AMOMIN.W (0b10000)
 							case 20: rs2 = ((int32_t)rs2>(int32_t)rval)?rs2:rval; break; //AMOMAX.W (0b10100)
-							case 24: rs2 = (rs2<rval)?rs2:rval; break; //AMOMINU.W (0b11000)
-							case 28: rs2 = (rs2>rval)?rs2:rval; break; //AMOMAXU.W (0b11100)
-							default: trap = (2+1); dowrite = 0; break; //Not supported.
+							case 24: rs2 = ((uint32_t)rs2<(uint32_t)rval)?rs2:rval; break; //AMOMINU.W (0b11000)
+							case 28: rs2 = ((uint32_t)rs2>(uint32_t)rval)?rs2:rval; break; //AMOMAXU.W (0b11100)
+							default: trap = (1+MCAUSE_ILLEGAL_INSTRUCTION); dowrite = 0; break; //Not supported.
 						}
 						if( dowrite ) MINIRV32_STORE4( rs1, rs2 );
 					}
 					break;
 				}
-				default: trap = (2+1); // Fault: Invalid opcode.
+				default: trap = (1+MCAUSE_ILLEGAL_INSTRUCTION); // Fault: Invalid opcode.
 			}
 
 			// If there was a trap, do NOT allow register writeback.
@@ -535,8 +626,7 @@ MINIRV32_STEPPROTO
 		pc += 4;
 	}
 
-	if( CSR( cyclel ) > cycle ) CSR( cycleh )++;
-	SETCSR( cyclel, cycle );
+	SET_MCYCLE(cycle);
 	SETCSR( pc, pc );
 	return 0;
 }

--- a/mini-rv32ima/spec.h
+++ b/mini-rv32ima/spec.h
@@ -1,0 +1,104 @@
+
+
+#include <stdint.h>
+#ifndef XLEN
+#define XLEN 32
+#elif (XLEN != 32) || (XLEN != 64)
+#define XLEN 32
+#endif
+
+#if (XLEN == 32)
+typedef uint32_t xlen_t;
+typedef int32_t sxlen_t;
+typedef uint64_t xlen2_t;
+typedef int64_t sxlen2_t;
+#define SXLEN_MIN INT32_MIN
+#define XLEN_MAX UINT32_MAX
+#else
+typedef uint64_t xlen_t;
+typedef int64_t sxlen_t;
+typedef uint128_t xlen2_t;
+typedef int128_t sxlen2_t;
+#define SXLEN_MIN INT64_MIN
+#define XLEN_MAX UINT64_MAX
+#endif
+
+#define MSTATUS_MIE_BIT 3
+#define MSTATUS_MPIE_BIT 7
+#define MSTATUS_MPP_START_BIT 11
+
+#define MCAUSE_INTERRUPT_BIT (XLEN-1)
+#define MCAUSE_INSTRUCTION_ADDR_MISALIGNED 0
+#define MCAUSE_INSTRUCTION_ACCESS_FAULT 1
+#define MCAUSE_ILLEGAL_INSTRUCTION 2
+#define MCAUSE_BREAKPOINT 3
+#define MCAUSE_LOAD_ADDR_MISALIGNED 4
+#define MCAUSE_LOAD_ACCESS_FAULT 5
+#define MCAUSE_STORE_ADDR_MISALIGNED 6
+#define MCAUSE_STORE_ACCESS_FAULT 7
+#define MCAUSE_ECALL_FROM_U 8
+#define MCAUSE_ECALL_FROM_S 9
+#define MCAUSE_ECALL_FROM_M 11
+
+#define MIP_MTIP_BIT 7
+
+#define EXTRAFLAGS_WFI_BIT 2
+
+#define GET_RD(ir) ((ir >> 7) & 0x1f)
+#define GET_RS1(ir) ( (ir >> 15) & 0x1f )
+#define GET_RS2(ir) ( (ir >> 20) & 0x1f )
+#define GET_OPCODE(ir) (ir & 0x7f)
+#define GET_FUNC3(ir) ( ( ir >> 12 ) & 0x7 )
+#define GET_CSR_ADDR(ir) (ir >> 20)
+#if (XLEN == 64)
+#define UTYPE_IMM(ir) ((uint64_t)((int32_t)( ir & 0xfffff000 )))
+#define JTYPE_IMM(ir) ((uint64_t)((int32_t)(((uint32_t)(((int32_t)(ir & 0x80000000))>>11)) | ((ir & 0x7fe00000)>>20) | ((ir & 0x00100000)>>9) | ((ir&0x000ff000)))))
+#define ITYPE_IMM(ir) ((uint64_t)(((int32_t)ir) >> 20))
+#define BTYPE_IMM(ir) ((uint64_t)((int32_t)(((ir & 0xf00)>>7) | ((ir & 0x7e000000)>>20) | ((ir & 0x80) << 4) | ((uint32_t)((((int32_t)ir) >> 31)<<12)))))
+#define STYPE_IMM(ir) ((uint64_t)((int32_t)(( ( ir >> 7 ) & 0x1f ) | ((uint32_t)( ((int32_t)( ir & 0xfe000000 )) >> 20 )))))
+#else
+#define UTYPE_IMM(ir) ( ir & 0xfffff000 )
+#define JTYPE_IMM(ir) (((uint32_t)(((int32_t)(ir & 0x80000000))>>11)) | ((ir & 0x7fe00000)>>20) | ((ir & 0x00100000)>>9) | ((ir&0x000ff000)))
+#define ITYPE_IMM(ir) ((uint32_t)(((int32_t)ir) >> 20))
+#define BTYPE_IMM(ir) (((ir & 0xf00)>>7) | ((ir & 0x7e000000)>>20) | ((ir & 0x80) << 4) | ((uint32_t)((((int32_t)ir) >> 31)<<12)))
+#define STYPE_IMM(ir) (( ( ir >> 7 ) & 0x1f ) | ((uint32_t)( ((int32_t)( ir & 0xfe000000 )) >> 20 )))
+#endif
+
+#define OPCODE_LUI 0b0110111
+#define OPCODE_AUIPC 0b0010111
+#define OPCODE_JAL 0b1101111
+#define OPCODE_JALR 0b1100111
+#define OPCODE_BRANCH 0b1100011
+#define OPCODE_LOAD 0b0000011
+#define OPCODE_STORE 0b0100011
+#define OPCODE_OP 0b0110011
+#define OPCODE_OP_IMM 0b0010011
+#define OPCODE_MISC_MEM 0b0001111
+#define OPCODE_SYSTEM 0b1110011
+#define OPCODE_OP_32 0b0111011
+#define OPCODE_OP_IMM_32 0b0011011
+
+#define IS_FUNC7_MUL(ir) ( ir & 0x02000000 )
+#define IS_FUNC7_SUB(ir) ( ir & 0x40000000 )
+#define IS_FUNC7_SRA(ir) ( ir & 0x40000000 )
+#if (XLEN==64)
+#define SHIFT_MASK 0x3F
+#else
+#define SHIFT_MASK 0x1F
+#endif
+
+#if (XLEN==64)
+#define MXL 2
+#else
+#define MXL 1
+#endif
+
+#define MISA_READ (0x40401101UL | (((xlen_t)MXL) << (XLEN-2)))
+
+#if (XLEN==64)
+#define SET_MCYCLE(x) SETCSR( cycle, x )
+#else
+#define SET_MCYCLE(x) if( CSR( cyclel ) > x ) { CSR( cycleh )++; } SETCSR( cyclel, x )
+#endif
+
+#define RESERVATION_MASK 0xFFFFFFFFFFFFFFF8UL

--- a/riscv-tests-harness/Makefile
+++ b/riscv-tests-harness/Makefile
@@ -1,0 +1,34 @@
+REPO := riscv-tests
+PREFIX := ../buildroot/output/host/bin/riscv32-buildroot-linux-uclibc-
+OBJCOPY := $(PREFIX)objcopy
+EMULATOR := ../mini-rv32ima/mini-rv32ima
+JOBS ?= 4
+RISCV_GCC_OPTS ?= -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles -g -O1
+GROUP ?= rv32mi
+TARGET ?= $(GROUP)
+TEST ?= $(GROUP)-p-breakpoint
+TEST_ELF := $(REPO)/isa/$(TEST)
+TEST_BIN := $(TEST_ELF).bin
+
+all: run
+
+$(REPO):
+	git clone https://github.com/riscv-software-src/riscv-tests
+	cd $(REPO) && git submodule update --init --recursive
+
+configure: $(REPO)
+	cd $(REPO) && ./configure --prefix=
+
+build: configure
+	cd $(REPO) && make -j$(JOBS) XLEN=32 RISCV_PREFIX=$(abspath $(PREFIX)) RISCV_GCC_OPTS="$(RISCV_GCC_OPTS)" -C isa $(TARGET)
+
+$(TEST_BIN): $(TEST_ELF)
+	$(OBJCOPY) $< -O binary $@
+
+run: build $(TEST_BIN)
+	$(EMULATOR) -f $(TEST_BIN) -c 20000000 -d
+
+clean:
+	rm -rf $(REPO)
+
+.PHONY: all configure build run clean

--- a/riscv-tests-harness/README.md
+++ b/riscv-tests-harness/README.md
@@ -1,0 +1,22 @@
+# riscv-tests harness
+
+This folder provides a lightweight wrapper for building and running
+`riscv-tests` using the existing workspace toolchain and `mini-rv32ima`.
+
+By default the harness builds the `rv32mi` group and runs the
+`rv32mi-p-simple` test.
+
+Usage:
+
+  make -C riscv-tests-harness build
+  make -C riscv-tests-harness run
+  make -C riscv-tests-harness run TEST=rv32mi-p-add
+  make -C riscv-tests-harness run GROUP=rv32mi TEST=rv32mi-p-add
+  make -C riscv-tests-harness clean
+
+The root `Makefile` also exposes `make tests` to run the default riscv-test
+case.
+
+Note: `mini-rv32ima` loads a raw binary image and does not automatically
+exit on `tohost` writes, so this harness runs with a fixed instruction count
+and uses the emulator's fail-on-fault mode.


### PR DESCRIPTION
This PR introduces 64-bit (RV64) extension support to the emulator. 

I am opening this initially as a Draft/RFC to get early feedback on my approach. I will iterate on this and complete all remaining work so this can eventually be merged as one solid, cohesive update.

### **The Approach**
* Introduced a new `spec.h` file to handle architecture-specific macros and constants.
* Abstracted hardcoded 32-bit types into `xlen_t` and `sxlen_t` to allow switching between 32-bit and 64-bit modes.
* Implemented the 64-bit instruction variants (e.g., LD, SD, AMO*.D) alongside the existing 32-bit switch statements.
* Added new macros to streamline and clean up common tasks, such as generating immediates.

### **Current Status**
* RV32 uClinux still successfully boots and works with RV32 with current changes.
* RV64 support is implemented but not fully validated.

### **To-Do Before Marking Ready for Review:**
- [ ] Receive feedback on the `spec.h` and `xlen_t` architectural direction.
- [ ] Thoroughly test against `riscv-tests` for 64-bit.
- [ ] Get RV64 uClinux booting

Let me know if this direction aligns with the project's goals.